### PR TITLE
ci: harden GitHub Pages workflow with SPA fallback enforcement

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,4 +1,4 @@
-name: Deploy to GitHub Pages
+name: Deploy GitHub Pages (Vite SPA)
 
 on:
   push:
@@ -18,50 +18,21 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        
-      - name: Setup Node
-        uses: actions/setup-node@v4
+      - uses: actions/checkout@v4
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: npm
-          
-      - name: Install
-        run: npm ci
-        
-      - name: Configure base path for Pages
-        run: |
-          if [ -f CNAME ]; then 
-            echo "Using CNAME => base=/"
-            echo "VITE_BASE_PATH=/" >> $GITHUB_ENV
-          else 
-            echo "Using project pages => base=/${{ github.event.repository.name }}/"
-            echo "VITE_BASE_PATH=/${{ github.event.repository.name }}/" >> $GITHUB_ENV
-          fi
-          
-      - name: Setup production environment for Pages
-        run: |
-          # Copy production environment template
-          if [ -f .env.production.pages ]; then
-            cp .env.production.pages .env.production
-            echo "Using Pages-specific environment configuration"
-          else
-            echo "VITE_API_BASE=/api" >> .env.production
-            echo "VITE_WS_URL=/ws" >> .env.production
-            echo "Created basic production environment"
-          fi
-          
-      - name: Build
-        run: npm run build
-        
-      - name: Ensure SPA fallback files
-        run: |
-          [ -f docs/.nojekyll ] || touch docs/.nojekyll
-          [ -f docs/404.html ] || cp docs/index.html docs/404.html
-        
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+
+      - run: npm ci
+      - run: npm run build
+
+      - name: Enforce SPA fallback (.nojekyll + 404.html)
+        run: npm run ensure:spa
+
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: ./docs
 
@@ -72,6 +43,5 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
+      - id: deployment
         uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+project-backups/
 
 # Editor directories and files
 .vscode/*

--- a/docs/404.html
+++ b/docs/404.html
@@ -1,3 +1,22 @@
-<!doctype html><meta charset="utf-8">
-<meta http-equiv="refresh" content="0; url=./index.html">
-<script>location.replace('./index.html');</script>
+<!doctype html>
+<html lang="fa" dir="rtl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#0b1120" />
+    <meta name="description" content="Persian Legal AI Dashboard" />
+    <title>Persian Legal AI Dashboard</title>
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <script type="module" crossorigin src="/newboltailearn2/assets/index-izy1IMjv.js"></script>
+    <link rel="modulepreload" crossorigin href="/newboltailearn2/assets/vendor-ugrJR1sR.js">
+    <link rel="modulepreload" crossorigin href="/newboltailearn2/assets/ui-CKdBcnHP.js">
+    <link rel="modulepreload" crossorigin href="/newboltailearn2/assets/utils-BeLtu-UY.js">
+    <link rel="modulepreload" crossorigin href="/newboltailearn2/assets/charts-CW_cpWrm.js">
+    <link rel="modulepreload" crossorigin href="/newboltailearn2/assets/tensorflow-DZGbYn8l.js">
+    <link rel="modulepreload" crossorigin href="/newboltailearn2/assets/api--a0sVTLk.js">
+    <link rel="stylesheet" crossorigin href="/newboltailearn2/assets/index-Dm96Dghj.css">
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "reliability:status": "curl -s http://localhost:8080/api/reliability/status | jq",
     "reliability:health": "curl -s http://localhost:8080/api/reliability/health | jq",
     "reliability:test": "node scripts/test-reliability-systems.js",
-    "reliability:monitor": "node scripts/monitor-reliability.js"
+    "reliability:monitor": "node scripts/monitor-reliability.js",
+    "ensure:spa": "node scripts/ensure-spa-fallback.mjs"
   },
   "dependencies": {
     "@tensorflow/tfjs": "^4.22.0",

--- a/scripts/ensure-spa-fallback.mjs
+++ b/scripts/ensure-spa-fallback.mjs
@@ -1,0 +1,41 @@
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = `${__dirname}/..`;
+const indexPath = `${rootDir}/docs/index.html`;
+const fallbackPath = `${rootDir}/docs/404.html`;
+const noJekyllPath = `${rootDir}/docs/.nojekyll`;
+
+if (!existsSync(indexPath)) {
+  console.error(`[ERROR] ${indexPath} not found. Run the build before enforcing SPA fallback.`);
+  process.exit(1);
+}
+
+const indexHtml = readFileSync(indexPath, 'utf8');
+let shouldMirror = false;
+
+if (!existsSync(fallbackPath)) {
+  shouldMirror = true;
+} else {
+  const fallbackHtml = readFileSync(fallbackPath, 'utf8');
+  const redirectPattern = /<meta\s+http-equiv=["']refresh["']|location\.(replace|href)|<script>.*location/si;
+  if (redirectPattern.test(fallbackHtml)) {
+    shouldMirror = true;
+  }
+}
+
+if (shouldMirror) {
+  writeFileSync(fallbackPath, indexHtml);
+  console.log(`[ok] Ensured SPA fallback: ${fallbackPath} mirrors ${indexPath}`);
+} else {
+  console.log('[ok] docs/404.html already provides SPA fallback');
+}
+
+if (!existsSync(noJekyllPath)) {
+  writeFileSync(noJekyllPath, '');
+  console.log('[ok] Created docs/.nojekyll');
+} else {
+  console.log('[ok] docs/.nojekyll already exists');
+}


### PR DESCRIPTION
## Summary
- add an ensure-spa helper script and npm script to mirror index.html to 404.html and create .nojekyll
- refresh the built 404.html to match index.html and make sure project backups stay untracked
- replace the GitHub Pages workflow with the configure-pages based pipeline that runs the new fallback enforcement step

## Testing
- npm run ensure:spa

------
https://chatgpt.com/codex/tasks/task_e_68d7ec68670c832f8d60560e2c2c38e0