### PR TITLE
Fix favicon base path for GitHub Pages deployment

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="theme-color" content="#0b1120" />
     <meta name="description" content="Persian Legal AI Dashboard" />
     <title>Persian Legal AI Dashboard</title>
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="%BASE_URL%favicon.svg" />
   </head>
   <body>
     <div id="root"></div>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <defs>
+    <linearGradient id="g" x1="0" y1="64" x2="64" y2="0" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0ea5e9" />
+      <stop offset="1" stop-color="#6366f1" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#g)" />
+  <g stroke="#f8fafc" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M32 16v20" />
+    <path d="M20 28c0 6 5.373 11 12 11s12-5 12-11" />
+    <path d="M18 44h28" />
+    <path d="M26 28l-6 10" />
+    <path d="M38 28l6 10" />
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- update the HTML template to load the favicon using Vite's `%BASE_URL%` placeholder so GitHub Pages serves it from the repository base path
- add a branded SVG favicon so the site has a real icon when deployed

## Testing
- npm run build -- --emptyOutDir

------
https://chatgpt.com/codex/tasks/task_e_68d8a8cfd5a4832fb6d396f78ff99674